### PR TITLE
Added needed ecdsa dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url = "https://github.com/bitpay/bitpay-python",
     download_url = "https://github.com/bitpay/bitpay-python/tarball/v2.3.0",
     keywords = ["bitcoin", "payments", "crypto"],
+    install_requires = ["ecdsa"],
     classifiers = [
 "Programming Language :: Python",
 "Programming Language :: Python :: 3",


### PR DESCRIPTION
Please integrate, otherwise a "pip install bitpay" does not leave you in a working environment.