### PR TITLE
Added support for generic unsigned GET and POST calls

### DIFF
--- a/bitpay/client.py
+++ b/bitpay/client.py
@@ -17,7 +17,7 @@ class Client:
     if re.match("^\w{7,7}$", code) is None:
       raise BitPayArgumentError("pairing code is not legal")
     payload = {'id': self.client_id, 'pairingCode': code}
-    response = self.unsigned_get_request(payload)
+    response = self.unsigned_request('/tokens', payload)
     if response.ok:
       self.tokens = self.token_from_response(response.json())
       return self.tokens 
@@ -25,7 +25,7 @@ class Client:
 
   def create_token(self, facade):
     payload = {'id': self.client_id, 'facade': facade}
-    response = self.unsigned_get_request(payload)
+    response = self.unsigned_request('/tokens', payload)
     if response.ok:
       self.tokens = self.token_from_response(response.json())
       return response.json()['data'][0]['pairingCode']
@@ -86,10 +86,23 @@ class Client:
   def response_error(self, response):
     raise BitPayBitPayError('%(code)d: %(message)s' % {'code': response.status_code, 'message': response.json()['error']})
 
-  def unsigned_get_request(self, payload):
+  def unsigned_request(self, path, payload=None):
+    """
+    generic bitpay usigned wrapper
+    passing a payload will do a POST, otherwise a GET
+    """
     headers = {"content-type": "application/json", "accept": "application/json", "X-accept-version": "2.0.0"}
     try:
-      response = requests.post(self.uri + "/tokens", verify=self.verify, data=json.dumps(payload), headers=headers)
+      if payload:
+        response = requests.post(self.uri + path, verify=self.verify, data=json.dumps(payload), headers=headers)
+      else:
+        response = requests.get(self.uri + path, verify=self.verify, headers=headers)
     except Exception as pro:
       raise BitPayConnectionError('Connection refused')
     return response
+
+  def unsigned_get_request(self, path, payload=None):
+    """
+    Deprecated
+    """
+    return self.unsigned_request('/tokens', payload)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -29,4 +29,10 @@ class TestClient(unittest.TestCase):
       with self.assertRaisesRegex(BitPayBitPayError, "403: this is a 403 error"):
         new_client.create_invoice({"price": 20, "currency": "USD"})
 
-
+  def test_unsigned_request_rates(self):
+    """tests whether the generic wrapper returns properly
+       when asked for rates
+    """
+    new_client = Client()
+    request = new_client.unsigned_request('/rates/EUR')
+    self.assertIn('rate', request.json()['data'])


### PR DESCRIPTION
 * "unsigned_get_request" is now deprecated, as a not generic,
   POST only to '/tokens' wrapper that will be removed in a future release.