### PR TITLE
Allow access to invoices past 72h window

### DIFF
--- a/bitpay/client.py
+++ b/bitpay/client.py
@@ -46,9 +46,10 @@ class Client:
       return response.json()['data']
     self.response_error(response)
 
-  def get_invoice(self, invoice_id): 
+  def get_invoice(self, invoice_id):
     uri = self.uri + "/invoices/" + invoice_id
-    headers = {'accept': 'application/json'}
+    headers = {"content-type": "application/json", 'accept': 'application/json'}
+
     try:
       response = requests.get(uri, headers=headers, verify=self.verify)
     except Exception as pro:

--- a/bitpay/client.py
+++ b/bitpay/client.py
@@ -46,9 +46,15 @@ class Client:
       return response.json()['data']
     self.response_error(response)
 
-  def get_invoice(self, invoice_id):
-    uri = self.uri + "/invoices/" + invoice_id
-    headers = {"content-type": "application/json", 'accept': 'application/json'}
+  def get_invoice(self, invoice_id, token=None):
+    if token:
+      uri = self.uri + "/invoices/" + invoice_id + "?token=" + token
+      xidentity = key_utils.get_compressed_public_key_from_pem(self.pem)
+      xsignature = key_utils.sign(uri, self.pem)
+      headers = {"content-type": "application/json", 'accept': 'application/json', 'X-Identity': xidentity, 'X-Signature': xsignature, 'X-accept-version': '2.0.0'}
+    else:
+      uri = self.uri + "/invoices/" + invoice_id
+      headers = {"content-type": "application/json", 'accept': 'application/json'}
 
     try:
       response = requests.get(uri, headers=headers, verify=self.verify)


### PR DESCRIPTION
After pointing out the signup-form for the BitPay test-env in #18, I went ahead and did sign up there and started using the library against your service. Thank you for the hint!

This PR adds the possibility to retrieve invoices from the Merchant-Facade past the 72h limit by specifying an optional token.

I tried this change with the [pretix/pretix-bitpay](https://github.com/pretix/pretix-bitpay) plugin and the test.bitpay.com-environment and it seems to be working fine.